### PR TITLE
Code simplification: init parameters when instanciating StringVars

### DIFF
--- a/src/three_d_fin/gui/layout.py
+++ b/src/three_d_fin/gui/layout.py
@@ -212,9 +212,8 @@ class Application(tk.Tk):
 
         try:
             my_abs_path = my_file.resolve(strict=True)
-
         except FileNotFoundError:
-            print("Configuration file not found.")
+            pass
         else:
             print("Configuration file found. Setting default parameters from the file")
 


### PR DESCRIPTION
A minor change to avoid code redundancy: remove 50 lines of virtually "useless" code and improve readability.