### PR TITLE
Export only good clusters

### DIFF
--- a/src/three_d_fin/processing/abstract_processing.py
+++ b/src/three_d_fin/processing/abstract_processing.py
@@ -476,9 +476,7 @@ class FinProcessing(ABC):
         t_las = timeit.default_timer()
         # Export Stripe
 
-        clean_stripe = clust_stripe[
-            np.isin(clust_stripe[:, -1], tree_vector[:, 0])
-        ]
+        clean_stripe = clust_stripe[np.isin(clust_stripe[:, -1], tree_vector[:, 0])]
 
         self._export_stripe(clean_stripe)
 


### PR DESCRIPTION
Before this commit, all clusters discovered in the stripe were output in the corresponding LAS file. Now, only clusters that end up being part of a tree will be output.