### PR TITLE
On exception thread cleanup is too conservative

### DIFF
--- a/src/three_d_fin/__about__.py
+++ b/src/three_d_fin/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.0rc4"
+__version__ = "0.2.0rc5"
 
 # Copyright infos
 __copyright_info_1__ = (

--- a/src/three_d_fin/gui/application.py
+++ b/src/three_d_fin/gui/application.py
@@ -395,7 +395,6 @@ class Application(QMainWindow):
         def _error_handling(error_message: str) -> None:
             _enable_btn()
             QMessageBox.critical(self, "3DFin error", error_message)
-            self.thread.quit()
 
         # Now we do the processing in itself
         self.thread = QThread()


### PR DESCRIPTION
That make CC crash when 3DFin raises an exception.