### PR TITLE
[CCPlugin] Take into account global shift in tabular data. 

### DIFF
--- a/src/three_d_fin/cloudcompare/plugin_processing.py
+++ b/src/three_d_fin/cloudcompare/plugin_processing.py
@@ -284,28 +284,28 @@ class CloudComparePluginProcessing(FinProcessing):
     ):
         """We may need to revert the global shift in tabular data."""
         if self.base_cloud.isShifted():
-            print("Cloud is shifted")
+            print("Cloud is shifted, correcting tabular data coordinates.")
             global_shift = self.base_cloud.getGlobalShift()
             global_scale = self.base_cloud.getGlobalScale()
 
             # convert coordinates to global ones
-            X_c = X_c / global_scale[0] - global_shift[0]
-            Y_c = Y_c / global_scale[1] - global_shift[1]
-            R = R / global_scale[0]
+            X_c = X_c / global_scale - global_shift[0]
+            Y_c = Y_c / global_scale - global_shift[1]
+            R = R / global_scale
             tree_locations[:, 0] = (
-                tree_locations[:, 0] / global_scale[0] - global_shift[0]
+                tree_locations[:, 0] / global_scale - global_shift[0]
             )
             tree_locations[:, 1] = (
-                tree_locations[:, 1] / global_scale[1] - global_shift[1]
+                tree_locations[:, 1] / global_scale - global_shift[1]
             )
             tree_locations[:, 2] = (
-                tree_locations[:, 2] / global_scale[2] - global_shift[2]
+                tree_locations[:, 2] / global_scale - global_shift[2]
             )
-            tree_heights[:, 0] = tree_heights[:, 0] / global_scale[0] - global_shift[0]
-            tree_heights[:, 1] = tree_heights[:, 1] / global_scale[1] - global_shift[1]
-            tree_heights[:, 2] = tree_heights[:, 2] / global_scale[2] - global_shift[2]
-
-        print("Cloud is not shifted")
+            tree_heights[:, 0] = tree_heights[:, 0] / global_scale - global_shift[0]
+            tree_heights[:, 1] = tree_heights[:, 1] / global_scale - global_shift[1]
+            tree_heights[:, 2] = tree_heights[:, 2] / global_scale - global_shift[2]
+        
+        print("Exporting tabular data")
         super()._export_tabular_data(
             config,
             output_basepath,

--- a/src/three_d_fin/cloudcompare/plugin_processing.py
+++ b/src/three_d_fin/cloudcompare/plugin_processing.py
@@ -282,13 +282,18 @@ class CloudComparePluginProcessing(FinProcessing):
         cloud_size,
         cloud_shape,
     ):
-        """We may need to revert the global shift in tabular data."""
+        """Revert the Global shift in tabular data when needed.
+        
+        If the base cloud was shifted, the coordinates are converted back in global ones
+        before exporting the tabular data by simply calling the parent method.
+        see parent method for more details on parmeters.
+        """
         if self.base_cloud.isShifted():
             print("Cloud is shifted, correcting tabular data coordinates.")
             global_shift = self.base_cloud.getGlobalShift()
             global_scale = self.base_cloud.getGlobalScale()
 
-            # convert coordinates to global ones
+            # Convert coordinates to global ones.
             X_c = X_c / global_scale - global_shift[0]
             Y_c = Y_c / global_scale - global_shift[1]
             R = R / global_scale

--- a/src/three_d_fin/cloudcompare/plugin_processing.py
+++ b/src/three_d_fin/cloudcompare/plugin_processing.py
@@ -264,8 +264,49 @@ class CloudComparePluginProcessing(FinProcessing):
         self.base_group.addChild(cloud_tree_locations)
         self.cc_instance.addToDB(cloud_tree_locations, autoExpandDBTree=False)
 
-        def _export_tabular_data(
-            self,
+    def _export_tabular_data(
+        self,
+        config,
+        output_basepath,
+        X_c,
+        Y_c,
+        R,
+        check_circle,
+        sector_perct,
+        n_points_in,
+        sections,
+        outliers,
+        dbh_values,
+        tree_locations,
+        tree_heights,
+        cloud_size,
+        cloud_shape,
+    ):
+        """We may need to revert the global shift in tabular data."""
+        if self.base_cloud.isShifted():
+            print("Cloud is shifted")
+            global_shift = self.base_cloud.getGlobalShift()
+            global_scale = self.base_cloud.getGlobalScale()
+
+            # convert coordinates to global ones
+            X_c = X_c / global_scale[0] - global_shift[0]
+            Y_c = Y_c / global_scale[1] - global_shift[1]
+            R = R / global_scale[0]
+            tree_locations[:, 0] = (
+                tree_locations[:, 0] / global_scale[0] - global_shift[0]
+            )
+            tree_locations[:, 1] = (
+                tree_locations[:, 1] / global_scale[1] - global_shift[1]
+            )
+            tree_locations[:, 2] = (
+                tree_locations[:, 2] / global_scale[2] - global_shift[2]
+            )
+            tree_heights[:, 0] = tree_heights[:, 0] / global_scale[0] - global_shift[0]
+            tree_heights[:, 1] = tree_heights[:, 1] / global_scale[1] - global_shift[1]
+            tree_heights[:, 2] = tree_heights[:, 2] / global_scale[2] - global_shift[2]
+
+        print("Cloud is not shifted")
+        super()._export_tabular_data(
             config,
             output_basepath,
             X_c,
@@ -281,49 +322,4 @@ class CloudComparePluginProcessing(FinProcessing):
             tree_heights,
             cloud_size,
             cloud_shape,
-        ):
-            """We may need to revert the global shift in tabular data."""
-            if self.base_cloud.isGlobalShiftEnabled():
-                global_shift = self.base_cloud.getGlobalShift()
-                global_scale = self.base_cloud.getGlobalScale()
-
-                # convert coordinates to global ones
-                X_c = X_c / global_scale[0] - global_shift[0]
-                Y_c = Y_c / global_scale[1] - global_shift[1]
-                R = R / global_scale[0]
-                tree_locations[:, 0] = (
-                    tree_locations[:, 0] / global_scale[0] - global_shift[0]
-                )
-                tree_locations[:, 1] = (
-                    tree_locations[:, 1] / global_scale[1] - global_shift[1]
-                )
-                tree_locations[:, 2] = (
-                    tree_locations[:, 2] / global_scale[2] - global_shift[2]
-                )
-                tree_heights[:, 0] = (
-                    tree_heights[:, 0] / global_scale[0] - global_shift[0]
-                )
-                tree_heights[:, 1] = (
-                    tree_heights[:, 1] / global_scale[1] - global_shift[1]
-                )
-                tree_heights[:, 2] = (
-                    tree_heights[:, 2] / global_scale[2] - global_shift[2]
-                )
-
-            super()._export_tabular_data(
-                config,
-                output_basepath,
-                X_c,
-                Y_c,
-                R,
-                check_circle,
-                sector_perct,
-                n_points_in,
-                sections,
-                outliers,
-                dbh_values,
-                tree_locations,
-                tree_heights,
-                cloud_size,
-                cloud_shape,
-            )
+        )

--- a/src/three_d_fin/cloudcompare/plugin_processing.py
+++ b/src/three_d_fin/cloudcompare/plugin_processing.py
@@ -263,3 +263,67 @@ class CloudComparePluginProcessing(FinProcessing):
 
         self.base_group.addChild(cloud_tree_locations)
         self.cc_instance.addToDB(cloud_tree_locations, autoExpandDBTree=False)
+
+        def _export_tabular_data(
+            self,
+            config,
+            output_basepath,
+            X_c,
+            Y_c,
+            R,
+            check_circle,
+            sector_perct,
+            n_points_in,
+            sections,
+            outliers,
+            dbh_values,
+            tree_locations,
+            tree_heights,
+            cloud_size,
+            cloud_shape,
+        ):
+            """We may need to revert the global shift in tabular data."""
+            if self.base_cloud.isGlobalShiftEnabled():
+                global_shift = self.base_cloud.getGlobalShift()
+                global_scale = self.base_cloud.getGlobalScale()
+
+                # convert coordinates to global ones
+                X_c = X_c / global_scale[0] - global_shift[0]
+                Y_c = Y_c / global_scale[1] - global_shift[1]
+                R = R / global_scale[0]
+                tree_locations[:, 0] = (
+                    tree_locations[:, 0] / global_scale[0] - global_shift[0]
+                )
+                tree_locations[:, 1] = (
+                    tree_locations[:, 1] / global_scale[1] - global_shift[1]
+                )
+                tree_locations[:, 2] = (
+                    tree_locations[:, 2] / global_scale[2] - global_shift[2]
+                )
+                tree_heights[:, 0] = (
+                    tree_heights[:, 0] / global_scale[0] - global_shift[0]
+                )
+                tree_heights[:, 1] = (
+                    tree_heights[:, 1] / global_scale[1] - global_shift[1]
+                )
+                tree_heights[:, 2] = (
+                    tree_heights[:, 2] / global_scale[2] - global_shift[2]
+                )
+
+            super()._export_tabular_data(
+                config,
+                output_basepath,
+                X_c,
+                Y_c,
+                R,
+                check_circle,
+                sector_perct,
+                n_points_in,
+                sections,
+                outliers,
+                dbh_values,
+                tree_locations,
+                tree_heights,
+                cloud_size,
+                cloud_shape,
+            )

--- a/src/three_d_fin/cloudcompare/plugin_processing.py
+++ b/src/three_d_fin/cloudcompare/plugin_processing.py
@@ -283,7 +283,7 @@ class CloudComparePluginProcessing(FinProcessing):
         cloud_shape,
     ):
         """Revert the Global shift in tabular data when needed.
-        
+
         If the base cloud was shifted, the coordinates are converted back in global ones
         before exporting the tabular data by simply calling the parent method.
         see parent method for more details on parmeters.
@@ -297,19 +297,13 @@ class CloudComparePluginProcessing(FinProcessing):
             X_c = X_c / global_scale - global_shift[0]
             Y_c = Y_c / global_scale - global_shift[1]
             R = R / global_scale
-            tree_locations[:, 0] = (
-                tree_locations[:, 0] / global_scale - global_shift[0]
-            )
-            tree_locations[:, 1] = (
-                tree_locations[:, 1] / global_scale - global_shift[1]
-            )
-            tree_locations[:, 2] = (
-                tree_locations[:, 2] / global_scale - global_shift[2]
-            )
+            tree_locations[:, 0] = tree_locations[:, 0] / global_scale - global_shift[0]
+            tree_locations[:, 1] = tree_locations[:, 1] / global_scale - global_shift[1]
+            tree_locations[:, 2] = tree_locations[:, 2] / global_scale - global_shift[2]
             tree_heights[:, 0] = tree_heights[:, 0] / global_scale - global_shift[0]
             tree_heights[:, 1] = tree_heights[:, 1] / global_scale - global_shift[1]
             tree_heights[:, 2] = tree_heights[:, 2] / global_scale - global_shift[2]
-        
+
         print("Exporting tabular data")
         super()._export_tabular_data(
             config,

--- a/src/three_d_fin/processing/abstract_processing.py
+++ b/src/three_d_fin/processing/abstract_processing.py
@@ -676,6 +676,23 @@ class FinProcessing(ABC):
         # Exporting results
         # -------------------------------------------------------------------------------------------------------------
 
+        self._export_tabular_data(
+            config,
+            self.output_basepath,
+            X_c,
+            Y_c,
+            R,
+            check_circle,
+            sector_perct,
+            n_points_in,
+            sections,
+            outliers,
+            dbh_values,
+            tree_locations,
+            tree_heights,
+            cloud_size,
+            cloud_shape,
+        )
         elapsed_las2 = timeit.default_timer() - t_las2
         print("Total time:", "   %.2f" % elapsed_las2, "s")
 

--- a/src/three_d_fin/processing/abstract_processing.py
+++ b/src/three_d_fin/processing/abstract_processing.py
@@ -253,11 +253,11 @@ class FinProcessing(ABC):
         cloud_size,
         cloud_shape,
     ):
-        """Export the tabular data. 
-        
+        """Export the tabular data.
+
         It is a simple wrapper around the dedicated function in three_d_fin.processing.io.
         It could be overriden by implementers in order to add specific logic.
-        
+
         See export_tabular_data function in three_d_fin.processing.io for more details.
         """
         export_tabular_data(

--- a/src/three_d_fin/processing/abstract_processing.py
+++ b/src/three_d_fin/processing/abstract_processing.py
@@ -235,6 +235,43 @@ class FinProcessing(ABC):
         """
         pass
 
+    def _export_tabular_data(
+        self,
+        config,
+        output_basepath,
+        X_c,
+        Y_c,
+        R,
+        check_circle,
+        sector_perct,
+        n_points_in,
+        sections,
+        outliers,
+        dbh_values,
+        tree_locations,
+        tree_heights,
+        cloud_size,
+        cloud_shape,
+    ):
+        """Export the tabular data, it is a simple wrapper around the dedicated function so it could be overriden by implementers."""
+        export_tabular_data(
+            config,
+            output_basepath,
+            X_c,
+            Y_c,
+            R,
+            check_circle,
+            sector_perct,
+            n_points_in,
+            sections,
+            outliers,
+            dbh_values,
+            tree_locations,
+            tree_heights,
+            cloud_size,
+            cloud_shape,
+        )
+
     def process(self):
         """3DFin main algorithm.
 
@@ -638,23 +675,6 @@ class FinProcessing(ABC):
         # -------------------------------------------------------------------------------------------------------------
         # Exporting results
         # -------------------------------------------------------------------------------------------------------------
-        export_tabular_data(
-            config,
-            self.output_basepath,
-            X_c,
-            Y_c,
-            R,
-            check_circle,
-            sector_perct,
-            n_points_in,
-            sections,
-            outliers,
-            dbh_values,
-            tree_locations,
-            tree_heights,
-            cloud_size,
-            cloud_shape,
-        )
 
         elapsed_las2 = timeit.default_timer() - t_las2
         print("Total time:", "   %.2f" % elapsed_las2, "s")

--- a/src/three_d_fin/processing/abstract_processing.py
+++ b/src/three_d_fin/processing/abstract_processing.py
@@ -253,7 +253,13 @@ class FinProcessing(ABC):
         cloud_size,
         cloud_shape,
     ):
-        """Export the tabular data, it is a simple wrapper around the dedicated function so it could be overriden by implementers."""
+        """Export the tabular data. 
+        
+        It is a simple wrapper around the dedicated function in three_d_fin.processing.io.
+        It could be overriden by implementers in order to add specific logic.
+        
+        See export_tabular_data function in three_d_fin.processing.io for more details.
+        """
         export_tabular_data(
             config,
             output_basepath,


### PR DESCRIPTION
Previously, the tabular data exported from 3DFin CloudCompare plugin did not take into account the global shift. 
This PR change a bit the abstract_processing API by adding a dedicated method to export tabular data (previoulsy it was included in the `process` method). This method is overridden in CC context in order to take into account the global shift.

Another possible fix lives in this branch
https://github.com/3DFin/3DFin/tree/global_shift_fix_rc6