### PR TITLE
Release v0.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "lazrs~=0.5.0",
   "pandas~=2.0.0",
   "XlsxWriter~=3.1.0",
-  "dendromatics~=0.4.0",
+  "dendromatics~=0.4.1",
   "pydantic~=1.10.7",
   "PyQT5~=5.15"
 ]

--- a/src/three_d_fin/__about__.py
+++ b/src/three_d_fin/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 # Copyright infos
 __copyright_info_1__ = (


### PR DESCRIPTION
use latest `dedromatics` (0.4.1). It depends on our corrected version of `CSF` with speed improvements.