### PR TITLE
Continuous Delivery of CC and 3DFin

### DIFF
--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -1,0 +1,76 @@
+# This build file is inspired by https://github.com/tmontaigu/CloudCompare-PythonRuntime/blob/master/.github/workflows/Build.yml
+name: build cloudcompare plugin
+
+on: [ push, pull_request ]
+
+
+jobs:
+  Windows-Build:
+    name: Windows
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Clone CloudCompare
+        uses: actions/checkout@v4
+        with:
+          repository: 'CloudCompare/CloudCompare'
+          submodules: recursive
+
+      - name: Clone CC-PythonRuntime
+        uses: actions/checkout@v4
+        with:
+          repository: 'tmontaigu/CloudCompare-PythonRuntime'
+          path: 'plugins/private/CloudCompare-PythonRuntime'
+
+      - name: Install Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: CloudCompareDev
+          auto-activate-base: false
+          python-version: "3.10"
+          miniconda-version: 'latest'
+
+      - name: Install Dependencies
+        run: |
+          conda install -c conda-forge qt=5.12.* ninja doxygen
+          pip install pytest pybind11 numpy 3DFin
+
+      - name: Configure MSVC console
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Set environment for MSVC
+        run: |
+          # Set these env vars so cmake picks the correct compiler
+          # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files
+          echo "CXX=cl.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "CC=cl.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Configure CMake
+        shell: pwsh
+        run: |
+          mkdir build
+          cmake  `
+            -G Ninja `
+            -B build `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_INSTALL_PREFIX=install `
+            -DPLUGIN_PYTHON=ON `
+            -DPLUGIN_PYTHON_USE_EMBEDDED_MODULES=ON `
+            .
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Install
+        run: cmake --install build
+
+      - name: Run Tests
+        run: cmake --build build --target pytest
+      
+      - name: install
+        run: |
+          mkdir cloudcompare_install
+          cmake --install build --prefix "cloudcompare_install"
+        

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -79,7 +79,7 @@ jobs:
           mkdir cloudcompare_install
           cmake --install build --prefix "cloudcompare_install"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           name: 3dfin_cloudcompare_plugin
           path: cloudcompare_install/CloudCompare

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -70,10 +70,6 @@ jobs:
       - name: Build
         run: cmake --build build --parallel
 
-      # remove tests for now sincd we do not want to build with m3c2
-      # - name: Run Tests
-      #  run: cmake --build build --target pytest
-      
       - name: install
         run: |
           mkdir cloudcompare_install
@@ -83,3 +79,4 @@ jobs:
         with:
           name: 3dfin_cloudcompare_plugin
           path: cloudcompare_install/CloudCompare
+          compression-level: 1 # minimum compression we expect few uploads but a large amount of files to compress

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -26,12 +26,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: '3DFin_plugin'
-
+      
+      - name: Clone Laszip
+        uses: actions/checkout@v4
+        with:
+          repository: 'LASzip/LASzip'
+          ref: 3.4.3
+          path: laszip  
+   
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
-      
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
@@ -43,7 +49,7 @@ jobs:
           setup-python: false
       
 
-      - name: Install Dependencies
+      - name: Install Python Dependencies
         shell: pwsh
         run: |
           pip install pybind11 numpy
@@ -60,7 +66,24 @@ jobs:
           echo "CXX=cl.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "CC=cl.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Configure CMake
+      - name: Configure LASzip CMake
+        shell: pwsh
+        run: |
+          mkdir laszip/build
+          cmake  laszip `
+            -G Ninja `
+            -B laszip/build `
+
+      - name: Build LASzip
+        run: cmake --build laszip/build --parallel
+      
+      - name: Install LASzip
+        shell: pwsh
+        run: |
+          cmake --install laszip/build --prefix laszip/install
+          ls laszip/install
+
+      - name: Configure CC CMake
         shell: pwsh
         run: |
           mkdir build
@@ -69,25 +92,23 @@ jobs:
             -B build `
             -DCMAKE_BUILD_TYPE=Release `
             -DOPTION_BUILD_CCVIEWER=OFF `
-            -DCMAKE_INSTALL_PREFIX=install `
+            -DPLUGIN_IO_QLAS=ON `
+            -DLASZIP_INCLUDE_DIR=".\laszip\install\include\" `
+            -DLASZIP_LIBRARY=".\laszip\install\lib\laszip3.lib" `
             -DPLUGIN_PYTHON=ON `
             -DPYTHON_EXECUTABLE="C:\hostedtoolcache\windows\Python\3.10.11\x64\python.exe" `
             -DPLUGIN_PYTHON_USE_EMBEDDED_MODULES=ON `
             .
 
-      - name: Build
+      - name: Build CC
         run: cmake --build build --parallel
 
-      - name: install
+      - name: install CC
         run: |
           mkdir cloudcompare_install
           cmake --install build --prefix "cloudcompare_install"
       
-      - name: zip
-        shell: pwsh
-        run: Compress-Archive -Path cloudcompare_install/CloudCompare  -DestinationPath 3dfin_cloudcompare_plugin.zip
-
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           name: 3dfin_cloudcompare_plugin
-          path: 3dfin_cloudcompare_plugin.zip
+          path: cloudcompare_install/CloudCompare

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -8,8 +8,6 @@ jobs:
   Windows-Build:
     name: Windows
     runs-on: windows-latest
-    strategy:
-      fail-fast: false
 
     steps:
       - name: Clone CloudCompare
@@ -29,19 +27,29 @@ jobs:
         with:
           path: '3DFin_plugin'
 
-      - name: Install Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/setup-python@v5
         with:
-          activate-environment: CloudCompareDev
-          auto-activate-base: false
-          python-version: "3.10"
-          miniconda-version: 'latest'
+          python-version: '3.10'
+
+      
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v3
+        with:
+          version:      '5.15.2'
+          host:         windows
+          target:       desktop
+          arch:         win64_msvc2019_64
+          dir:          ${{ runner.temp }}
+          setup-python: false
+      
 
       - name: Install Dependencies
+        shell: pwsh
         run: |
-          conda install -c conda-forge qt=5.12.* ninja doxygen
           pip install pybind11 numpy
+          pip install ninja
           pip install 3DFin_plugin/
+          python -c "import sys;print(sys.executable)"
 
       - name: Configure MSVC console
         uses: ilammy/msvc-dev-cmd@v1
@@ -64,6 +72,7 @@ jobs:
             -DOPTION_BUILD_CCVIEWER=OFF `
             -DCMAKE_INSTALL_PREFIX=install `
             -DPLUGIN_PYTHON=ON `
+            -DPYTHON_EXECUTABLE="C:\hostedtoolcache\windows\Python\3.10.11\x64\python.exe" `
             -DPLUGIN_PYTHON_USE_EMBEDDED_MODULES=ON `
             .
 
@@ -75,8 +84,8 @@ jobs:
           mkdir cloudcompare_install
           cmake --install build --prefix "cloudcompare_install"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: 3dfin_cloudcompare_plugin
           path: cloudcompare_install/CloudCompare
-          compression-level: 1 # minimum compression we expect few uploads but a large amount of files to compress
+          compression-level: 6 

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -55,6 +55,7 @@ jobs:
             -G Ninja `
             -B build `
             -DCMAKE_BUILD_TYPE=Release `
+            -DOPTION_BUILD_CCVIEWER=OFF `
             -DCMAKE_INSTALL_PREFIX=install `
             -DPLUGIN_PYTHON=ON `
             -DPLUGIN_PYTHON_USE_EMBEDDED_MODULES=ON `
@@ -66,11 +67,16 @@ jobs:
       - name: Install
         run: cmake --install build
 
-      - name: Run Tests
-        run: cmake --build build --target pytest
+      # remove tests for now sincd we do not want to build with m3c2
+      # - name: Run Tests
+      #  run: cmake --build build --target pytest
       
       - name: install
         run: |
           mkdir cloudcompare_install
           cmake --install build --prefix "cloudcompare_install"
-        
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: 3dfin_cloudcompare_plugin
+          path: cloudcompare_install/install/cloudcompare

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -49,7 +49,6 @@ jobs:
           pip install pybind11 numpy
           pip install ninja
           pip install 3DFin_plugin/
-          python -c "import sys;print(sys.executable)"
 
       - name: Configure MSVC console
         uses: ilammy/msvc-dev-cmd@v1
@@ -83,9 +82,12 @@ jobs:
         run: |
           mkdir cloudcompare_install
           cmake --install build --prefix "cloudcompare_install"
+      
+      - name: zip
+        shell: pwsh
+        run: Compress-Archive -Path cloudcompare_install/CloudCompare  -DestinationPath 3dfin_cloudcompare_plugin.zip
 
       - uses: actions/upload-artifact@v4
         with:
           name: 3dfin_cloudcompare_plugin
-          path: cloudcompare_install/CloudCompare
-          compression-level: 6 
+          path: 3dfin_cloudcompare_plugin.zip

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -24,6 +24,11 @@ jobs:
           repository: 'tmontaigu/CloudCompare-PythonRuntime'
           path: 'plugins/private/CloudCompare-PythonRuntime'
 
+      - name: Clone 3DFin
+        uses: actions/checkout@v4
+        with:
+          path: '3DFin_plugin'
+
       - name: Install Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -35,7 +40,8 @@ jobs:
       - name: Install Dependencies
         run: |
           conda install -c conda-forge qt=5.12.* ninja doxygen
-          pip install pytest pybind11 numpy 3DFin
+          pip install pybind11 numpy
+          pip install 3DFin_plugin/
 
       - name: Configure MSVC console
         uses: ilammy/msvc-dev-cmd@v1
@@ -64,9 +70,6 @@ jobs:
       - name: Build
         run: cmake --build build --parallel
 
-      - name: Install
-        run: cmake --install build
-
       # remove tests for now sincd we do not want to build with m3c2
       # - name: Run Tests
       #  run: cmake --build build --target pytest
@@ -79,4 +82,4 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: 3dfin_cloudcompare_plugin
-          path: cloudcompare_install/install/cloudcompare
+          path: cloudcompare_install/CloudCompare

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get latest pip
         run: python -m pip install --upgrade pip


### PR DESCRIPTION
Add a GitHub action that build a minimal CloudCompare distribution with:
- CloudCompare-PythonRuntime 
- QLasIO
- 3DFin plugin

The distribution could be downloaded to from https://github.com/3DFin/3DFin/actions/workflows/build-cc.yml by selecting a specific run (for example this [one](https://github.com/3DFin/3DFin/actions/runs/8303002512)) and looking at the end of the page.

For now it's 100% usable but takes fair amount of time (about 35 minute of build) due to numerous file to upload via the `upload action`. I tried to zip the distribution without success. It will be handled in a future PR.