### PR TITLE
Improve 3DFin CC plugin CI

### DIFF
--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -116,7 +116,7 @@ jobs:
         shell: powershell
         run: |
           cd cloudcompare_install
-          Compress-Archive -Path ./CloudCompare/* -Destination cloudcompare_3dfin.zip
+          7z a -tzip cloudcompare.zip ./CloudCompare
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -114,6 +114,7 @@ jobs:
       - name: zip CC distribution
         shell: pwsh
         run: |
+          rm ./cloudcompare_install/CloudCompare/plugins/Python/python3.exe
           cd cloudcompare_install
           7z a -tzip cloudcompare.zip .\CloudCompare
 

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -113,10 +113,10 @@ jobs:
           cmake --install build --prefix "cloudcompare_install"
 
       - name: zip CC distribution
-        shell: powershell
+        shell: pwsh
         run: |
           cd cloudcompare_install
-          7z a -tzip cloudcompare.zip ./CloudCompare
+          7z a -tzip cloudcompare.zip .\CloudCompare
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -114,7 +114,9 @@ jobs:
 
       - name: zip CC distribution
         shell: powershell
-        run: Compress-Archive -Path ./cloudcompare_install/CloudCompare/* -Destination cloudcompare_3dfin.zip
+        run: |
+          cd cloudcompare_install
+          Compress-Archive -Path ./CloudCompare/* -Destination cloudcompare_3dfin.zip
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -114,9 +114,8 @@ jobs:
       - name: zip CC distribution
         shell: pwsh
         run: |
-          rm ./cloudcompare_install/CloudCompare/plugins/Python/python3.exe
-          cd cloudcompare_install
-          7z a -tzip cloudcompare.zip .\CloudCompare
+          rm .\cloudcompare_install\CloudCompare\plugins\Python\python3.exe #rm this file it does not exists (sic.) !
+          7z a -tzip cloudcompare_3dfin.zip .\cloudcompare_install\CloudCompare
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -100,7 +100,6 @@ jobs:
             -DLASZIP_INCLUDE_DIR=".\laszip\install\include\" `
             -DLASZIP_LIBRARY=".\laszip\install\lib\laszip3.lib" `
             -DPLUGIN_PYTHON=ON `
-            -DPython_EXECUTABLE="C:\hostedtoolcache\windows\Python\3.10.11\x64\python.exe" `
             -DPLUGIN_PYTHON_USE_EMBEDDED_MODULES=ON `
             .
 

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -112,7 +112,7 @@ jobs:
           mkdir cloudcompare_install
           cmake --install build --prefix "cloudcompare_install"
  
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: 3dfin_cloudcompare_plugin
           path: cloudcompare_install/CloudCompare

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: zip CC distribution
         shell: powershell
-        run: Compress-Archive -Path cloudcompare_install/CloudCompare/* -Destination cloudcompare_3dfin.zip
+        run: Compress-Archive -Path ./cloudcompare_install/CloudCompare/* -Destination cloudcompare_3dfin.zip
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -100,7 +100,7 @@ jobs:
             -DLASZIP_INCLUDE_DIR=".\laszip\install\include\" `
             -DLASZIP_LIBRARY=".\laszip\install\lib\laszip3.lib" `
             -DPLUGIN_PYTHON=ON `
-            -DPYTHON_EXECUTABLE="C:\hostedtoolcache\windows\Python\3.10.11\x64\python.exe" `
+            -DPython_EXECUTABLE="C:\hostedtoolcache\windows\Python\3.10.11\x64\python.exe" `
             -DPLUGIN_PYTHON_USE_EMBEDDED_MODULES=ON `
             .
 

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -111,8 +111,12 @@ jobs:
         run: |
           mkdir cloudcompare_install
           cmake --install build --prefix "cloudcompare_install"
- 
+
+      - name: zip CC distribution
+        shell: powershell
+        run: Compress-Archive -Path cloudcompare_install/CloudCompare/* -Destination cloudcompare_3dfin.zip
+
       - uses: actions/upload-artifact@v4
         with:
           name: 3dfin_cloudcompare_plugin
-          path: cloudcompare_install/CloudCompare
+          path: cloudcompare_3dfin.zip


### PR DESCRIPTION
 - Migrate to GHA upload@v4
 - ZIp CC folder before upload
 
the build process is now faster and the download process should be